### PR TITLE
Python3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,3 +42,12 @@ Usage example::
     rabbit.declare_queue(queue_name)
     rabbit.send_message(queue_name, "body text")
     rabbit.close_connection()
+
+
+Strings vs. bytes
+-----------------
+
+RabbitMQ messages are bytes, though they may optionally have an encoding flag. When consuming messages, in Python 3, they are received as bytes, and should be decoded::
+
+    method, properties, body = rabbit.get_message(queue_name)
+    message = body.decode(properties.content_encoding or 'ascii')

--- a/eea/rabbitmq/client/rabbitmq.py
+++ b/eea/rabbitmq/client/rabbitmq.py
@@ -41,7 +41,7 @@ class RabbitMQConnector(object):
                     credentials=self.__rabbit_credentials,
                     heartbeat_interval=0))
             self.__rabbit_channel = self.__rabbit_connection.channel()
-        except Exception, err:
+        except Exception as err:
             logger.error(
                 'CONNECTING to RabbitMQ at %s:%s FAILED with error: %s',
                 self.__rabbit_host,
@@ -60,7 +60,7 @@ class RabbitMQConnector(object):
             self.__rabbit_connection.close()
             self.__rabbit_connection = None
             self.__rabbit_channel = None
-        except Exception, err:
+        except Exception as err:
             logger.error(
                 'DISCONNECTING from RabbitMQ at %s:%s FAILED with error: %s',
                 self.__rabbit_host,

--- a/eea/rabbitmq/client/setuphandlers.py
+++ b/eea/rabbitmq/client/setuphandlers.py
@@ -1,14 +1,13 @@
 """ SetupHandlers
 """
 from Products.CMFQuickInstallerTool import interfaces as QuickInstaller
-from zope.interface import implements
+from zope.interface import implementer
 
 
+@implementer(QuickInstaller.INonInstallable)
 class HiddenProducts(object):
     """ HiddenProducts
     """
-
-    implements(QuickInstaller.INonInstallable)
 
     def getNonInstallableProducts(self):
         """Do not show on QuickInstaller's list of installable products."""

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(name=NAME,
           "Programming Language :: Zope",
           "Programming Language :: Python",
           "Programming Language :: Python :: 2.7",
+          "Programming Language :: Python :: 3",
           "Topic :: Software Development :: Libraries :: Python Modules",
           "License :: OSI Approved :: GNU General Public License (GPL)",
       ],
@@ -37,7 +38,7 @@ setup(name=NAME,
       zip_safe=True,
       install_requires=[
           'setuptools',
-          'pika'
+          'pika==0.13.1'
       ],
       extras_require={
           'test': [

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(name=NAME,
       zip_safe=True,
       install_requires=[
           'setuptools',
-          'pika==0.13.1'
+          'pika<1.0'
       ],
       extras_require={
           'test': [


### PR DESCRIPTION
Port to Python 3.
* Encode messages before sending them to the queue
* Document how to decode them - this can't be completely solved from the library code because the user may register their own consumer callback, which will be called directly from pika.
* Pin Pika to the last version before 1.0 (which breaks the API)
